### PR TITLE
Fix setup fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,11 @@ setup(
         'docs': ['docs/*'],
         'examples': ['examples/*']
     },
-    install_requires=requirements,
+    install_requires=list(requirements),
     extras_require={'python_version<3.0': extras_require},
     setup_requires=setup_require,
     test_suite='nose.collector',
-    tests_require=dev_requirements,
+    tests_require=list(dev_requirements),
     license=license,
     zip_safe=False,
     keywords=[project] + description.split(' '),


### PR DESCRIPTION
fix #19 
    This commit fix setup.py error
    error in meza setup
    "command: 'tests_require' must be
    a string or list of strings
    containing valid project/version
    requirement specifiers; Unordered
    types are not allowed"
