### PR TITLE
At the end of the generator, catch StopIteration and return none

### DIFF
--- a/meza/io.py
+++ b/meza/io.py
@@ -653,9 +653,12 @@ def read_mdb(filepath, table=None, **kwargs):
         header = list(ft.dedupe(uscored) if dedupe else uscored)
 
         for line in iter(pipe.readline, b""):
-            next_line = StringIO(str(line))
-            values = next(csv.reader(next_line, **kwargs))
-            yield dict(zip(header, values))
+            try:
+                next_line = StringIO(str(line))
+                values = next(csv.reader(next_line, **kwargs))
+                yield dict(zip(header, values))
+            except StopIteration:
+                return None
 
 
 def read_dbf(filepath, **kwargs):


### PR DESCRIPTION
When looping through the generator to get the rows/records or converting the record to an array/dataframe, I am getting `RuntimeError: generator raised StopIteration`. This seems to be a [Python 3.7 issue with the PEP 479](https://stackoverflow.com/a/51701040). 

```shell
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/meza/io.py", line 664, in read_mdb
    values = next(csv.reader(next_line, **kwargs))
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "main.py", line 7, in <module>
    arr = convert.records2array(records, result["types"])
  File "/usr/local/lib/python3.7/site-packages/meza/convert.py", line 710, in records2array
    data = [tuple(r.get(id_) for id_ in ids) for r in records]
  File "/usr/local/lib/python3.7/site-packages/meza/convert.py", line 710, in <listcomp>
    data = [tuple(r.get(id_) for id_ in ids) for r in records]
RuntimeError: generator raised StopIteration
```

To fix this issue, when `StopIteration` is raised in `read_mdb()`, catch the exception and return `None` instead of having `StopIteration` transformed into a `RuntimeError`.